### PR TITLE
Produce an informative error message if ocamlformat doesn't exist or fails

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -52,8 +52,13 @@ let parse_toml filename : config option =
 let run cmd =
   let inp = Unix.open_process_in cmd in
   let r = In_channel.input_all inp in
-  In_channel.close inp;
-  r
+  let res = Unix.close_process_in inp in
+  match res with
+  | Ok _ -> r
+  | Error (`Exit_non_zero 127) ->
+    Printf.ksprintf failwith "failed to run %s: command not found" cmd
+  | Error _ ->
+    Printf.ksprintf failwith "failed to run %s: command exited with an error" cmd
 
 let ocamlformat args =
   let args = String.concat ~sep:" " args in

--- a/src/main.ml
+++ b/src/main.ml
@@ -56,9 +56,10 @@ let run cmd =
   match res with
   | Ok _ -> r
   | Error (`Exit_non_zero 127) ->
-    Printf.ksprintf failwith "failed to run %s: command not found" cmd
+      Printf.ksprintf failwith "failed to run %s: command not found" cmd
   | Error _ ->
-    Printf.ksprintf failwith "failed to run %s: command exited with an error" cmd
+      Printf.ksprintf failwith "failed to run %s: command exited with an error"
+        cmd
 
 let ocamlformat args =
   let args = String.concat ~sep:" " args in


### PR DESCRIPTION
Right now if you copy the binary to a machine without ocamlformat installed, it will fail with an error about wrong ocamlformat version rather than with a more informative message saying that it's not there at all.

The fix employs closing the input channel with `Unix.close_process_in` gets you an exit status that you can use to check if the process succeeded and produce an error otherwise.