### PR TITLE
Use OTOML instead of To.ml for config parsing

### DIFF
--- a/fromager.opam
+++ b/fromager.opam
@@ -8,9 +8,9 @@ license: "Apache-2.0"
 homepage: "https://github.com/mimoo/fromager"
 bug-reports: "davidwong.crypto@gmail.com"
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
-  "toml" {>= "7.0"}
+  "otoml" {>= "0.9.2"}
   "core" {>= "v0.12.4"}
   "ocamlformat"
 ]

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
  (public_name fromager)
- (libraries core toml))
+ (libraries core otoml))

--- a/src/main.ml
+++ b/src/main.ml
@@ -15,34 +15,34 @@ let parse_toml filename : config option =
   | `No | `Unknown -> None
   | `Yes ->
       let toml =
-        match Toml.Parser.from_filename filename with
-        | `Error _ -> failwith "could not parse fromage.toml"
-        | `Ok toml -> toml
+        match Otoml.Parser.from_file_result filename with
+        | Error msg -> Printf.ksprintf failwith "could not parse fromage.toml:\n%s" msg
+        | Ok toml -> toml
       in
       let config =
-        match Toml.Types.Table.find_opt (Toml.Min.key "config") toml with
-        | Some (TTable config) -> config
+        match Otoml.find_opt toml Otoml.get_table ["config"] with
+        | Some config -> Otoml.table config
         | _ -> failwith "fromage.toml has no config table"
       in
       let ocamlformat_version =
         match
-          Toml.Types.Table.find_opt (Toml.Min.key "ocamlformat_version") config
+          Otoml.find_opt config Otoml.get_string ["ocamlformat_version"]
         with
-        | Some (TString ocamlformat_version) -> Some ocamlformat_version
+        | Some _ as ov -> ov
         | _ -> None
       in
       let ignored_files =
         match
-          Toml.Types.Table.find_opt (Toml.Min.key "ignored_files") config
+          Otoml.find_opt config (Otoml.get_array Otoml.get_string) ["ignored_files"]
         with
-        | Some (TArray (NodeString ignored_files)) -> ignored_files
+        | Some ignored_files -> ignored_files
         | _ -> []
       in
       let ignored_dirs =
         match
-          Toml.Types.Table.find_opt (Toml.Min.key "ignored_dirs") config
+          Otoml.find_opt config (Otoml.get_array Otoml.get_string) ["ignored_dirs"]
         with
-        | Some (TArray (NodeString ignored_dirs)) -> ignored_dirs
+        | Some ignored_dirs -> ignored_dirs
         | _ -> []
       in
       Some { ocamlformat_version; ignored_files; ignored_dirs }

--- a/src/main.ml
+++ b/src/main.ml
@@ -16,31 +16,36 @@ let parse_toml filename : config option =
   | `Yes ->
       let toml =
         match Otoml.Parser.from_file_result filename with
-        | Error msg -> Printf.ksprintf failwith "could not parse fromage.toml:\n%s" msg
+        | Error msg ->
+            Printf.ksprintf failwith "could not parse fromage.toml:\n%s" msg
         | Ok toml -> toml
       in
       let config =
-        match Otoml.find_opt toml Otoml.get_table ["config"] with
+        match Otoml.find_opt toml Otoml.get_table [ "config" ] with
         | Some config -> Otoml.table config
         | _ -> failwith "fromage.toml has no config table"
       in
       let ocamlformat_version =
         match
-          Otoml.find_opt config Otoml.get_string ["ocamlformat_version"]
+          Otoml.find_opt config Otoml.get_string [ "ocamlformat_version" ]
         with
         | Some _ as ov -> ov
         | _ -> None
       in
       let ignored_files =
         match
-          Otoml.find_opt config (Otoml.get_array Otoml.get_string) ["ignored_files"]
+          Otoml.find_opt config
+            (Otoml.get_array Otoml.get_string)
+            [ "ignored_files" ]
         with
         | Some ignored_files -> ignored_files
         | _ -> []
       in
       let ignored_dirs =
         match
-          Otoml.find_opt config (Otoml.get_array Otoml.get_string) ["ignored_dirs"]
+          Otoml.find_opt config
+            (Otoml.get_array Otoml.get_string)
+            [ "ignored_dirs" ]
         with
         | Some ignored_dirs -> ignored_dirs
         | _ -> []


### PR DESCRIPTION
[OTOML](https://opam.ocaml.org/packages/otoml/) is a TOML library I made to alleviate the shortcomings of To.ml, especially its TOML spec compatibility issues and overly verbose lookup API.

The most immediately visible improvement is informative parse error messages:

```
$ cat fromage.toml
[config]
ocamlformat_version = "0.18.0"
ignored_files = ["./tests/test.ml" # missing closing bracket
ignored_dirs = []

$ fromager
Uncaught exception:
  
  (Failure
    "could not parse fromage.toml:\
   \nSyntax error on line 4, character 1: Malformed array (missing closing square bracket?)\
   \n")

Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Dune__exe__Main.parse_toml in file "src/main.ml", line 19, characters 23-87
Called from Dune__exe__Main in file "src/main.ml", line 140, characters 15-41
```

I made minimal changes to your code structure, but you could also check if the `[config]` table exists separately using the `Otoml.path_exists` function (if you want that check) and retrieve actual values from it in one step with expressions like `Otoml.find_opt toml Otoml.get_string ["config"; "ocamlformat_version"].`
