### PR TITLE
Add support for passing options to ocamlformat from the TOML config

### DIFF
--- a/fromager.opam
+++ b/fromager.opam
@@ -10,7 +10,7 @@ bug-reports: "davidwong.crypto@gmail.com"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
-  "otoml" {>= "0.9.2"}
+  "otoml" {>= "0.9.3"}
   "core" {>= "v0.12.4"}
   "ocamlformat"
 ]


### PR DESCRIPTION
Right now fromager will either generate an empty .ocamlformat config or leave use the user's config if it exists. However, that way the user has to maintain two config files.

Instead we could keep options for ocamlformat in a sub-table and trivially translate them to a .ocamlformat

I use underscores in key names for consistency with fromager's native options and translate underscores to hyphens. Here's a sample config I tested it with:

```toml
$ cat fromage.toml 
[config]
ocamlformat_version = "0.19.0"
ignored_files = ["./tests/test.ml"]
ignored_dirs = []

[ocamlformat_options]
let_binding_spacing = "compact"
let_binding_indent = 4
leading_nested_match_parens = true
```